### PR TITLE
remove tkinter from try block

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
+from tkinter import *
 try:
-    from tkinter import *
     from pytube import YouTube
 except ModuleNotFoundError:
     print("please install pytube using 'pip install pytube' in cmd or terminal before running this script.")


### PR DESCRIPTION
the import of tkinter does not have to be placed in the try block responsible for catching the ModuleNotFoundError for a missing pytube installation.